### PR TITLE
adding twistlock scanning plugin from Steelcase

### DIFF
--- a/stable/twistlock-scan/Dockerfile
+++ b/stable/twistlock-scan/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:xenial
+
+ENV LANG C.UTF-8
+
+RUN { \
+      echo '#!/bin/sh'; \
+      echo 'set -e'; \
+      echo; \
+      echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+    } > /usr/local/bin/docker-java-home && \
+    chmod +x /usr/local/bin/docker-java-home
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bzip2 \
+      unzip \
+      xz-utils \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      software-properties-common \
+      python3-openssl && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable" && \
+    apt-get update && apt-get install -y --no-install-recommends \
+	  docker-ce=17.09.0~ce-0~ubuntu && \
+    apt-get install -y \
+      openjdk-8-jre \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    [ "$JAVA_HOME" = "$(docker-java-home)" ]; \
+    \
+    update-alternatives --get-selections | awk -v home="$JAVA_HOME" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+    update-alternatives --query java | grep -q 'Status: manual' && \
+    mkdir /packages && \
+    curl -o /packages/twistcli https://cdn.twistlock.com/support/twistcli && \
+    curl -o /packages/nexus-iq-cli-1.38.0-02.jar https://download.sonatype.com/clm/scanner/nexus-iq-cli-1.38.0-02.jar
+
+COPY scripts /scripts
+
+RUN	chmod +x -R /packages
+RUN	chmod +x -R /scripts
+
+WORKDIR /scripts
+
+ENTRYPOINT ["/usr/bin/python3"]
+CMD [""]

--- a/stable/twistlock-scan/LICENSE.md
+++ b/stable/twistlock-scan/LICENSE.md
@@ -1,0 +1,7 @@
+© 2017 Steelcase Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/stable/twistlock-scan/README.md
+++ b/stable/twistlock-scan/README.md
@@ -1,0 +1,105 @@
+# Security Scanning Tools [![Codefresh build status]( https://g.codefresh.io/api/badges/build?repoOwner=SC-TechDev&repoName=docker-security-scanner&branch=master&pipelineName=docker-security-scanner&accountName=sctechdevservice&type=cf-1)]( https://g.codefresh.io/repositories/SC-TechDev/docker-security-scanner/builds?filter=trigger:build;branch:master;service:59e62c5410e3d100019e7f3d~docker-security-scanner)
+
+Docker image which invokes security script using TwistCLI (Nexus coming soon)
+
+### Prerequisites:
+
+Codefresh Subscription (Dedicated Infrastructure) - https://codefresh.io/
+
+Twistlock Subscription - https://www.twistlock.com/
+
+### Documentation:
+
+Twistlock CLI: https://twistlock.desk.com/customer/en/portal/articles/2875595-twistcli?b_id=16619
+
+Nexus IQ CLI: TBD
+
+## Script Library
+
+### twistlock.py
+
+Executes TwistCLI to scan Docker image given.
+
+### options
+
+To use an ENVIRONMENT VARIABLE you need to add the variables to your Codefresh Pipeline and also to your codefresh.yaml.
+
+
+Example `codefresh.yml` build is below with required ENVIRONMENT VARIABLES in place.
+
+
+| ENVIRONMENT VARIABLE | SCRIPT ARGUMENT | DEFAULT | TYPE | REQUIRED | DESCRIPTION |
+|----------------------------|--------------------------------------|----------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------|
+| CF_METADATA | [ -c, --cf_metadata ] | null | boolean | No | In combination with TL_UPLOAD stores Twistlock Report URL in TL_REPORT_URL var for Codefresh metadata annotation |
+| TL_CONSOLE_HOSTNAME | [ -C, --tl_console_hostname ] | null | string | Yes | hostname/ip |
+| TL_CONSOLE_PORT | [ -P, --tl_console_port ] | null | string | Yes | port |
+| TL_CONSOLE_USERNAME | [ -U, --tl_console_username ] | null | string | Yes | username |
+| TL_CONSOLE_PASSWORD | [ -X, --tl_console_password ] | null | string | Yes | password |
+| TL_ONLY | [ -Z, --tl_only ] | null | boolean | Yes | Twistlock Console Only (Required for now Nexus TBD) |
+| TL_TLS_ENABLED | [ -T, --tl_tls_enabled ] | null | boolean | No | enable TLS |
+| TL_HASH | [ -H, --tl_hash ] | [ sha1 ] | string | No | [ md5, sha1, sha256 ] hashing algorithm |
+| TL_UPLOAD | [ -R, --tl_upload ] | null | boolean | No | ( ignores all options below if set and only returns report url ) uploads report to Twistlock to be used later via Twistlock API |
+| TL_DETAILS | [ -D, --tl_details ] | null | boolean | No | prints an itemized list of each vulnerability found by the scanner |
+| TL_ONLY_FIXED | [ -O, --tl_only_fixed ] | null | boolean | No | reports just the vulnerabilites that have fixes available |
+| TL_COMPLIANCE_THRESHOLD | [ -M, --tl_compliance_threshold ] | null | string | No | [ low, medium, high ] sets the the minimal severity compliance issue that returns a fail exit code |
+| TL_VULNERABILITY_THRESHOLD | [ -V, --tl_vulnerability_threshold ] | null | string | No | [ low, medium, high, critical ] sets the minimal severity vulnerability that returns a fail exit code |
+
+### codefresh.yml
+
+Codefresh Build Step to execute Twistlock scan.
+All `${{var}}` variables must be put into Codefresh Build Parameters
+codefresh.yml
+```console
+  buildimage:
+    type: build
+    title: Build Runtime Image
+    dockerfile: Dockerfile
+    image_name: # Image you're building/scanning [repository/image]
+    tag: latest-cf-build-candidate
+
+  nexus_iq_scan_build_stage:
+    type: composition
+    composition:
+      version: '2'
+      services:
+        imagebuild:
+          image: ${{buildimage}}
+          command: sh -c "exit 0"
+          labels:
+            build.image.id: ${{CF_BUILD_ID}}
+    composition_candidates:
+      scan_service:
+        image: sctechdev/docker-security-scanner
+        environment:
+          - TL_CONSOLE_HOSTNAME=${{TL_CONSOLE_HOSTNAME}}
+          - TL_CONSOLE_PORT=${{TL_CONSOLE_PORT}}
+          - TL_CONSOLE_USERNAME=${{TL_CONSOLE_USERNAME}}
+          - TL_CONSOLE_PASSWORD=${{TL_CONSOLE_PASSWORD}}
+          - TL_ONLY=${{TL_ONLY}}
+        command: twistlock.py -i "$$(docker inspect $$(docker inspect $$(docker ps -aqf label=build.image.id=${{CF_BUILD_ID}}) -f {{.Config.Image}}) -f {{.Id}} | sed 's/sha256://g')"
+        depends_on:
+          - imagebuild
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+          - /var/lib/docker:/var/lib/docker
+          # Everything below this line is Optional for CF_METADATA
+          - '${{CF_VOLUME_NAME}}:/codefresh/volume'
+    add_flow_volume_to_composition: true
+
+  export:
+    title: "Exporting variables..."
+    image: alpine
+    commands:
+      - echo "Exporting variables..."
+
+  set_metadata:
+    title: "Setting metadata on image..."
+    image: alpine
+    commands:
+      - echo "Setting metadata on image..."
+    on_finish:
+      metadata:
+        set:
+          - '${{build_step.imageId}}':
+              - TwistlockSecurityReport: ${{TL_REPORT_URL}}
+```

--- a/stable/twistlock-scan/codefresh.yml
+++ b/stable/twistlock-scan/codefresh.yml
@@ -1,0 +1,41 @@
+version: '1.0'
+
+steps:
+
+  buildimage:
+    type: build
+    description: image build step
+    dockerfile: Dockerfile
+    image_name: sctechdev/docker-security-scanner
+    tag: latest-cf-build-candidate
+
+  push_image:
+    type: push
+    candidate: ${{buildimage}}
+    tag: latest
+    when:
+      branch:
+        only:
+          - master
+  push_image1:
+    type: push
+    candidate: ${{buildimage}}
+    tag: ${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}
+
+  push_image_nexus_latest:
+    title: Push to Nexus Repo (latest)
+    type: push
+    candidate: ${{buildimage}}
+    tag: latest
+    registry: sonatype-docker-internal
+    when:
+      branch:
+        only:
+          - master
+
+  push_image_neuxs_gitbranch_gitsha:
+    title: Push to Nexus Repo (gitbranch + gitsha)
+    type: push
+    candidate: ${{buildimage}}
+    tag: ${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}
+    registry: sonatype-docker-internal

--- a/stable/twistlock-scan/plugin.yaml
+++ b/stable/twistlock-scan/plugin.yaml
@@ -1,0 +1,65 @@
+image: docker.io/sctechdev/docker-security-scanner
+tag: master-c81e6d4
+version: 2.2
+description: Execute Twistlock image scan as build step
+keywords:
+  - Twistlock 2.2
+home: https://hub.docker.com/r/sctechdev/docker-security-scanner/
+sources:
+  - https://github.com/SC-TechDev/docker-security-scanner
+maintainers: 
+  - name: Dustin Van Buskirk
+    email: dev@vanbuskirk.me
+  - name: Varun Tagore
+    email: rondevops@gmail.com
+icon: A URL to an SVG or PNG image to be used as an icon (optional)
+envs:
+  - name: CF_METADATA
+    type: required
+    description: Boolean; combination with TL_UPLOAD stores Twistlock Report URL in TL_REPORT_URL var for Codefresh metadata annotation
+  - name: TL_CONSOLE_HOSTNAME
+    type: required
+    description: Hostname or IP of Twistlock Console
+  - name: TL_CONSOLE_PORT
+    type: required
+    description: Port of Twistlock Console
+  - name: TL_CONSOLE_USERNAME
+    type: required
+    description: Username of Twistlock Console
+  - name: TL_CONSOLE_PASSWORD
+    type: required
+    description: Password of Twistlock Console User
+  - name: TL_ONLY
+    type: required
+    description: Twistlock Console Scan Only (No Nexus)
+  - name: TL_TLS_ENABLED
+    type: optional
+    description: Boolean; Enable TLS connection to Twistlock Console
+  - name: TL_HASH
+    type: optional
+    description: Hashing Algorithm to use
+  - name: TL_UPLOAD
+    type: optional
+    description: Upload report to Twistlock Console and return URL (Overrides all other options only returns URL)
+  - name: TL_DETAILS
+    type: optional
+    description: Prints an itemized list of each vulnerability found by the scanner
+  - name: TL_ONLY_FIXED
+    type: optional
+    description: reports just the vulnerabilites that have fixes available
+  - name: TL_COMPLIANCE_THRESHOLD
+    type: optional
+    description: [ low, medium, high ] sets the the minimal severity compliance issue that returns a fail exit code
+  - name: TL_VULNERABILITY_THRESHOLD
+    type: optional
+    description: [ low, medium, high, critical ] sets the minimal severity vulnerability that returns a fail exit code
+volumes:
+  - name: /var/run/docker.sock:/var/run/docker.sock
+    required: true
+    description: Docker socket for DIND
+  - name: /var/lib/docker:/var/lib/docker
+    required: true
+    description: Docker lib access for DIND
+  - name: '${{CF_VOLUME_NAME}}:/codefresh/volume'
+    required: false
+    description: Volume required if setting Docker image metadata using Codefresh

--- a/stable/twistlock-scan/scripts/twistlock.py
+++ b/stable/twistlock-scan/scripts/twistlock.py
@@ -1,0 +1,195 @@
+import sys
+import subprocess
+import time
+import os
+import getopt
+import ssl
+import re
+
+def main(argv):
+  try:
+    st_scanner_jar = '/packages/nexus-iq-cli-1.38.0-02.jar'
+    tl_scanner_exec = '/packages/twistcli'
+    cf_metadata = os.environ.get('CF_METADATA')
+    docker_image_id = os.environ.get('DOCKER_IMAGE_ID')
+    st_application_id = os.environ.get('NEXUS_IQ_APPLICATION_ID')
+    st_url = os.environ.get('NEXUS_IQ_URL')
+    st_username = os.environ.get('NEXUS_IQ_USERNAME')
+    st_password = os.environ.get('NEXUS_IQ_PASSWORD')
+    st_stage = os.environ.get('NEXUS_IQ_STAGE', 'Build')
+    tl_console_hostname = os.environ.get('TL_CONSOLE_HOSTNAME')
+    tl_console_port = os.environ.get('TL_CONSOLE_PORT')
+    tl_console_username = os.environ.get('TL_CONSOLE_USERNAME')
+    tl_console_password = os.environ.get('TL_CONSOLE_PASSWORD')
+    tl_only = os.environ.get('TL_ONLY')
+    tl_tls_enabled = os.environ.get('TL_TLS_ENABLED')
+    tl_hash = os.environ.get('TL_HASH', 'sha1')
+    tl_include_package_files = os.environ.get('TL_INCLUDE_PACKAGE_FILES')
+    tl_upload = os.environ.get('TL_UPLOAD')
+    tl_details = os.environ.get('TL_DETAILS')
+    tl_only_fixed = os.environ.get('TL_ONLY_FIXED')
+    tl_compliance_threshold = os.environ.get('TL_COMPLIANCE_THRESHOLD')
+    tl_vulnerability_threshold = os.environ.get('TL_VULNERABILITY_THRESHOLD')
+    java_home = os.environ.get('JAVA_HOME', '/usr/lib/jvm/java-8-openjdk-amd64')
+    java_keystore_password = os.environ.get('JAVA_KEYSTORE_PASSWORD', 'changeit')
+    opts, args = getopt.getopt(argv,"h:c:i:a:j:u:p:s:t:E:C:P:U:X:Z:J:K:T:H:F:R:D:O:M:V:",
+      ["help", "docker_image_id=", "cf_metadata", "st_application_id=", "st_scanner_jar=", "st_url=", "st_username=", "st_password=", "st_stage=",
+        "tl_scanner_exec=", "tl_console_hostname", "tl_console_port", "tl_console_username=", "tl_console_password=", "tl_only",
+        "tl_tls_enabled", "tl_hash", "tl_include_package_files", "tl_upload", "tl_details", "tl_only_fixed", "tl_compliance_threshold",
+        "tl_vulnerability_threshold", "java_home=", "java_keystore_password"
+      ]
+    )
+  except getopt.GetoptError:
+    print('Unrecognized Argument! See arguments list using -h or --help. Ex. twistlock.py --help')
+    sys.exit(2)
+  for opt, arg in opts:
+    if opt == ("h","--help"):
+      print('twistlock.py --arg value or twistlock.py -a value')
+      print('-c --cf_metadata - Adds scanner info to Docker image metadata for Codefresh builds')
+      print('-i --docker_image_id [DOCKER_IMAGE_ID] - Docker Image ID short or long IDs accepted')
+      print('-a --st_application_id [NEXUS_IQ_APPLICATION_ID] - Applications ID in Nexus IQ')
+      print('-j --st_scanner_jar - Location of nexus-iq-cli*.jar file')
+      print('-u --st_username [NEXUS_IQ_USERNAME] - Nexus IQ Username')
+      print('-p --st_password [NEXUS_IQ_PASSWORD] - Password for Nexus IQ Username')
+      print('-s --st_url [NEXUS_IQ_URL] - Sonatype URL must be HTTPS with Valid Cert')
+      print('-t --st_stage [NEXUS_IQ_STAGE] - Sonatype Stage')
+      print('-E --tl_scanner_exec - Location of twistlock-scanner executable')
+      print('-C --tl_console_hostname [TL_CONSOLE_HOSTNAME] - Hostname/IP for Twistlock Console')
+      print('-P --tl_console_port [TL_CONSOLE_PORT] - Twistock Console port')
+      print('-U --tl_console_username [TL_CONSOLE_USERNAME] - Twistlock Console Username')
+      print('-X --tl_console_password [TL_CONSOLE_PASSWORD] - Password for Twistlock Console Username')
+      print('-Z --tl_only [TL_ONLY] - Run a stand-alone Twistlock scan')
+      print('-T --tl_tls_enabled [TL_TLS_ENABLED] - Enabled TLS/HTTPS for Twistlock scan')
+      print('-H --tl_hash [TL_HASH] - Specifies the hashing algorithm. Supported values are md5, sha1, and sha256')
+      print('-F --tl_include_package_files [TL_INCLUDE_PACKAGE_FILES] - List all packages in the image')
+      print('-R --tl_upload [TL_UPLOAD] - Whether to upload the scan result')
+      print('-D --tl_details [TL_DETAILS] - Prints an itemized list of each vulnerability found by the scanner')
+      print('-O --tl_only_fixed [TL_ONLY_FIXED] - Reports just the vulnerabilities that have fixes available')
+      print('-M --tl_compliance_threshold [TL_COMPLIANCE_THRESHOLD] - Sets the minimum severity compliance issue that returns a fail exit code')
+      print('-V --tl_vulnerability_threshold [TL_VULNERABILITY_THRESHOLD] - Sets the minimum severity vulnerability that returns a fail exit code')
+      print('-J --java_home [JAVA_HOME] - Java Home Directory (no trailing /)')
+      print('-K --java_keystore_password [JAVA_KEYSTORE_PASSWORD] - Java Keystore Password')
+      sys.exit()
+    elif opt in ("-c", "--cf_metadata"):
+      cf_metadata = arg
+    elif opt in ("-i", "--docker_image_id"):
+      docker_image_id = arg
+    elif opt in ("-a", "--st_application_id"):
+      st_application_id = arg
+    elif opt in ("-j", "--st_scanner_jar"):
+      st_scanner_jar = arg
+    elif opt in ("-s", "--st_url"):
+      st_url = arg
+    elif opt in ("-u", "--st_username"):
+      st_username = arg
+    elif opt in ("-p", "--st_password"):
+      st_password = arg
+    elif opt in ("-t", "--st_stage"):
+      st_stage = arg
+    elif opt in ("-E", "--tl_scanner_exec"):
+      tl_scanner_exec = arg
+    elif opt in ("-C", "--tl_console_hostname"):
+      tl_console_hostname = arg
+    elif opt in ('-P', "--tl_console_port"):
+      tl_console_port = arg
+    elif opt in ("-U", "--tl_console_username"):
+      tl_console_username = arg
+    elif opt in ('-X', "--tl_console_password"):
+      tl_console_password = arg
+    elif opt in ('-Z', "--tl_only"):
+      tl_only = arg
+    elif opt in ('-T', "--tl_tls_enabled"):
+      tl_tls_enabled = arg
+    elif opt in ('-H', "--tl_hash"):
+      tl_hash = arg
+    elif opt in ('-F', "--tl_include_package_files"):
+      tl_include_package_files = arg
+    elif opt in ('-R', "--tl_upload"):
+      tl_upload = arg
+    elif opt in ('-D', "--tl_details"):
+      tl_details = arg
+    elif opt in ('-O', "--tl_only_fixed"):
+      tl_only_fixed = arg
+    elif opt in ('-M', "--tl_compliance_threshold"):
+      tl_compliance_threshold = arg
+    elif opt in ('-V', "--tl_vulnerability_threshold"):
+      tl_vulnerability_threshold = arg
+    elif opt in ('-J', "--java_home"):
+      java_home = arg
+    elif opt in ('-K', "--java_keystore_password"):
+      java_keystore_password = arg
+
+  # Determine if TLS is required
+  if not (tl_only or tl_tls_enable):  
+    # Download and store Twistlock Console site cert
+    cert = ssl.get_server_certificate((tl_console_hostname, tl_console_port))
+    cert, file=open("twistlock.cer", "w")
+  
+  # Run stand-alone Twistlock Scan
+  if tl_only: 
+    
+    # Determine Protocol
+    tl_console_protocol = 'https' if tl_tls_enabled else 'http'
+    
+    # Base twistcli commnad to scan images
+    twistcli_base_command = '/packages/twistcli images scan'
+    
+    # Required twistcli options to successfully scan image
+    twistcli_required_options = ("--address '{}://{}:{}' --user '{}' --password '{}' --hash '{}'"
+      .format(tl_console_protocol, tl_console_hostname, tl_console_port, tl_console_username, tl_console_password, tl_hash))
+
+    # Optional twistcli options
+    options = []
+    if tl_include_package_files: 
+      options.append("--include-package-files")
+    if tl_upload: 
+      options.append("--upload")
+    if tl_details: 
+      options.append("--details")
+    if tl_compliance_threshold: 
+      options.append("--compliance-threshold '{}'".format(tl_compliance_threshold))
+    if tl_vulnerability_threshold: 
+      options.append("--vulnerability-threshold '{}'".format(tl_vulnerability_threshold))
+    twistcli_optional_options = ' '.join(options)
+
+    # Concatenate twistcli executable with command
+    twistcli_exec = ' '.join([twistcli_base_command, twistcli_required_options, twistcli_optional_options, docker_image_id])
+    # Execute command but pipe stdout to variable and parse for Twistlock URL
+    if cf_metadata:
+      proc = subprocess.Popen(twistcli_exec, shell=True, stdout=subprocess.PIPE)
+      stdout = proc.communicate()[0].decode('utf-8').strip('\n')
+      tl_report_url = ''.join(re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', stdout))
+      with open('/codefresh/volume/env_vars_to_export', 'a') as f:
+        print('Twistlock Report: ' + tl_report_url)
+        f.write('TL_REPORT_URL=' + tl_report_url)
+        f.close()
+    # Execute command and send stdout to console
+    else:
+      proc = subprocess.Popen(twistcli_exec, shell=True)
+      stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+      sys.exit(1)
+
+  else:
+    
+    # Import site cert into java keystore
+    command = ['keytool -importcert -noprompt -file twistlock.cer -alias twistlock -storepass {} -keystore {}/jre/lib/security/cacerts'
+      .format(java_keystore_password, java_home)
+    ]
+    proc = subprocess.Popen(command, shell=True)
+    stdout, stderr = proc.communicate()
+
+    # Start Docker
+    command = ['for i in {1..5}; do service docker start && break || sleep 15; done']
+    proc = subprocess.Popen(command, shell=True)
+    stdout, stderr = proc.communicate()
+        
+    # Run Twistlock Scan and send file to Sonatype
+    command = ["java -cp {} com.sonatype.insight.scan.cli.TwistlockPolicyEvaluatorCli -i {} -a '{}:{}' -s '{}' --twistlock-scanner-executable {} --twistlock-console-url https://{}:{} --twistlock-console-username {} --twistlock-console-password '{}' --stage '{}' {}"
+      .format(st_scanner_jar, st_application_id, st_username, st_password, st_url, tl_scanner_exec, tl_console_hostname, tl_console_port, tl_console_username, tl_console_password, st_stage, docker_image_id)
+    ]
+    proc = subprocess.Popen(command, shell=True)
+    stdout, stderr = proc.communicate()
+
+if __name__ == "__main__":
+  main(sys.argv[1:])


### PR DESCRIPTION
Adding Steelcase's Security integration plugin that can be used to execute a Twistlock scan of the candidate image as a build step and return either a report URL or results to the build log and also fail your builds if vulnerability or compliance threshold set is exceeded.