### PR TITLE
Add pypi-publish contribution

### DIFF
--- a/submit.json
+++ b/submit.json
@@ -24,4 +24,5 @@
 { "name" : "cf-run-jenkins-jobs", "url": "https://github.com/codefresh-contrib/cf-run-jenkins-jobs" },
 { "name" : "cfstep-gitclonerssh", "url": "https://github.com/codefresh-contrib/cfstep-gitclonerssh" },
 { "name" : "cfstep-gitsubmodules", "url": "https://github.com/codefresh-contrib/cfstep-gitsubmodules" },
-{ "name" : "sendgridplugin", "url": "https://github.com/codefresh-contrib/sendgridplugin" }]
+{ "name" : "sendgridplugin", "url": "https://github.com/codefresh-contrib/sendgridplugin" },
+{ "name" : "pypi-publish", "url": "https://github.com/biarri/pypi-publish" }]


### PR DESCRIPTION
Following the existing npm-publish plugin for Codefresh as closely as possible, this minimal plugin will perform a twine upload of a previously packaged dist.